### PR TITLE
Implementing catering menu & notices, info banner change, and adding catering to menu options

### DIFF
--- a/website/src/app/catering/page.tsx
+++ b/website/src/app/catering/page.tsx
@@ -1,21 +1,47 @@
-import { CateringForm } from "@/components/catering-form";
 import { Navbar } from "@/components/navbar";
+import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
+import { Menu } from "@/components/menu";
+import { CookingPot } from "lucide-react"
+import { fallbackCateringMenu, fallbackCateringMenuDate } from "@/lib/constants";
+
+const CACHE_KEY = "cateringMenuCache";
+const CACHE_EXPIRATION_KEY = "cateringMenuCacheExpiration";
+const MAIN_MENU_SHEET_LINK = "https://docs.google.com/spreadsheets/d/e/2PACX-1vQFe8zXVdVW7slOpUu8hsp32MnnEz1ZGRivhEWJjaBUIWxz5jRXd8qYjKrZ05KEQG0F-kT1YFlFiSaZ/pub?output=csv&gid=678587674";
+
 
 export default function CateringPage() {
   return (
     <div>
       <Navbar />
-      <div className="text-center">
-        <h1 className="text-4xl">Catering</h1>
-        Some catering info
-      </div>
-      <div className="flex justify-center items-center min-h-screen">
-        <div className="w-11/12 h-[90vh]">
-          <embed
-            src={`https://docs.google.com/gview?url=https://www.kome-austin.com/miso/wp-content/uploads/2024/07/Kome-Menu-Lunch.pdf&embedded=true`}
-            className="w-full h-full"
-          />
+      <div className="min-h-screen w-full bg-[#f5f5f5] p-8">
+        <div className="max-w-6xl mx-auto">
+          <Alert className="bg-[#b77e08] text-white">
+            <CookingPot color="white" className="text-white h-4 w-4" />
+            <AlertTitle><div className="text-lg font-bold">Catering Notices</div></AlertTitle>
+            <AlertDescription>
+              <ul className="list-disc">
+                <li>
+                  Catering orders require a minimum of 48 hours notice. Call 616-376-4002
+                </li>
+                <li>
+                  Napkins, flatware, and serving utensils are available upon request
+                </li>
+                <li>
+                  {/* TODO: this file is hosted on personal google drive, change to client's drive */}
+                  Download the catering menu <a className="underline" href="https://drive.google.com/file/d/161gl3zU7yXzT7j6zJF7ptXBEyMCk62ur/view?usp=sharing" target="_blank">here</a>
+                </li>
+              </ul>
+            </AlertDescription>
+          </Alert>
+          <div className="columns-1 md:columns-2 gap-4">
+          </div>
         </div>
+        <Menu
+          menuSheetUrl={MAIN_MENU_SHEET_LINK}
+          cacheKey={CACHE_KEY}
+          cacheExpirationKey={CACHE_EXPIRATION_KEY}
+          fallbackMenu={fallbackCateringMenu}
+          fallbackMenuDate={fallbackCateringMenuDate} />
       </div>
     </div>
   );

--- a/website/src/app/catering/page.tsx
+++ b/website/src/app/catering/page.tsx
@@ -1,11 +1,22 @@
-import { CateringForm } from "@/components/catering-form"
-import { Navbar } from "@/components/navbar"
+import { CateringForm } from "@/components/catering-form";
+import { Navbar } from "@/components/navbar";
 
 export default function CateringPage() {
   return (
     <div>
       <Navbar />
-      <CateringForm />
+      <div className="text-center">
+        <h1 className="text-4xl">Catering</h1>
+        Some catering info
+      </div>
+      <div className="flex justify-center items-center min-h-screen">
+        <div className="w-11/12 h-[90vh]">
+          <embed
+            src={`https://docs.google.com/gview?url=https://www.kome-austin.com/miso/wp-content/uploads/2024/07/Kome-Menu-Lunch.pdf&embedded=true`}
+            className="w-full h-full"
+          />
+        </div>
+      </div>
     </div>
-  )
+  );
 }

--- a/website/src/app/menu/page.tsx
+++ b/website/src/app/menu/page.tsx
@@ -1,11 +1,21 @@
 import { Menu } from "@/components/menu";
 import { Navbar } from "@/components/navbar";
+import { fallbackMainMenu, fallbackMainMenuDate } from '@/lib/constants';
+
+const CACHE_KEY = "menuCache";
+const CACHE_EXPIRATION_KEY = "menuCacheExpiration";
+const MAIN_MENU_SHEET_LINK = "https://docs.google.com/spreadsheets/d/e/2PACX-1vQFe8zXVdVW7slOpUu8hsp32MnnEz1ZGRivhEWJjaBUIWxz5jRXd8qYjKrZ05KEQG0F-kT1YFlFiSaZ/pub?output=csv";
 
 export default function Home() {
   return (
     <div>
       <Navbar />
-      <Menu/>
+      <Menu
+        menuSheetUrl={MAIN_MENU_SHEET_LINK}
+        cacheKey={CACHE_KEY}
+        cacheExpirationKey={CACHE_EXPIRATION_KEY}
+        fallbackMenu={fallbackMainMenu}
+        fallbackMenuDate={fallbackMainMenuDate} />
     </div>
   );
 }

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -5,7 +5,7 @@ import { InfoBanner } from "@/components/info-banner";
 export default function Home() {
   return (
     <div>
-      <InfoBanner message="Call 616-376-4002 to reserve a table"/>
+      <InfoBanner message="Catering now available." link="/catering"/>
       <Navbar />
       <FullScreenCarousel/>
       <div className="bg-[#FAF9F6] flex flex-col items-center py-12 space-y-4">

--- a/website/src/components/info-banner.tsx
+++ b/website/src/components/info-banner.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 
 interface InfoBannerProps {
   message: string;
+  link?: string;
 }
 
 export function InfoBanner(props: InfoBannerProps) {
@@ -17,7 +18,7 @@ export function InfoBanner(props: InfoBannerProps) {
     isVisible && (
       <div className="bg-[#b77e08] text-white p-4 left-0 w-full shadow-lg">
         <div className="flex justify-between items-center max-w-6xl mx-auto">
-          <p className="text-lg">{props.message}</p>
+          <p className="text-lg inline">{props.message}{props.link && <> See <a className='underline' href={props.link}>here</a></>}</p>
           <button
             onClick={dismissBanner}
             className="text-[#702963] hover:text-gray-300 focus:outline-none"

--- a/website/src/components/menu-item.tsx
+++ b/website/src/components/menu-item.tsx
@@ -5,7 +5,7 @@ interface MenuItemProps {
   bulkPrice?: string // currently only used for wine by the bottle
 }
 
-export function MenuItem({ name, description, price, bulkPrice }: MenuItemProps) {
+export function MenuItemComponent({ name, description, price, bulkPrice }: MenuItemProps) {
   return (
     <div className="border-b border-gray-200 pb-4">
       <div className="flex justify-between items-start gap-4 mt-2">
@@ -14,7 +14,7 @@ export function MenuItem({ name, description, price, bulkPrice }: MenuItemProps)
           {description && <p className="text-sm text-gray-600 mt-1">{description}</p>}
         </div>
         {
-          price && 
+          price &&
             <div className="font-semibold whitespace-nowrap">
               ${price}{bulkPrice && ` / $${bulkPrice}`}
             </div>

--- a/website/src/components/menu.tsx
+++ b/website/src/components/menu.tsx
@@ -1,36 +1,28 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { MenuItem as MenuItemComponent } from "@/components/menu-item";
-import Papa from "papaparse";
-import { fallbackMenu, fallbackMenuDate } from '@/lib/constants';
+import { MenuItemComponent } from "@/components/menu-item";
+import { fallbackMainMenu, fallbackMainMenuDate } from '@/lib/constants';
+import { fetchMenuData } from '@/data-fetcher/sheet-fetcher';
 
-interface CsvMenuDataRow {
-  category: 'FOOD' | 'DRINKS';
-  typeName: string;
-  typeDescription?: string;
-  itemName: string;
-  itemDescription?: string;
-  itemPrice?: number;
-  itemBulkPrice?: number;
-}
+
 
 export interface Menu {
   food: MenuCategory;
   drinks: MenuCategory;
 }
 
-interface MenuCategory {
+export interface MenuCategory {
   sections: MenuSection[];
 }
 
-interface MenuSection {
+export interface MenuSection {
   type: string;
   description?: string;
   items: MenuItem[];
 }
 
-interface MenuItem {
+export interface MenuItem {
   name: string;
   description?: string;
   price?: number;
@@ -39,11 +31,11 @@ interface MenuItem {
 
 const CACHE_KEY = "menuCache";
 const CACHE_EXPIRATION_KEY = "menuCacheExpiration";
-const CACHE_TTL = 1000 * 60 * 60 * 24; // 1 day expiration
+const MAIN_MENU_SHEET_LINK = "https://docs.google.com/spreadsheets/d/e/2PACX-1vQFe8zXVdVW7slOpUu8hsp32MnnEz1ZGRivhEWJjaBUIWxz5jRXd8qYjKrZ05KEQG0F-kT1YFlFiSaZ/pub?output=csv";
 
 export function Menu() {
   const [menuCategorySelection, setMenuCategorySelection] = useState<'FOOD' | 'DRINKS'>('FOOD');
-  const [menu, setMenu] = useState<Menu>(fallbackMenu);
+  const [menu, setMenu] = useState<Menu>(fallbackMainMenu);
 
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);
@@ -63,92 +55,7 @@ export function Menu() {
     }
 
     async function fetchData() {
-      try {
-        const dataUrl = "https://docs.google.com/spreadsheets/d/e/2PACX-1vQFe8zXVdVW7slOpUu8hsp32MnnEz1ZGRivhEWJjaBUIWxz5jRXd8qYjKrZ05KEQG0F-kT1YFlFiSaZ/pub?output=csv";
-        const dataResponse = await fetch(dataUrl, {
-          redirect: "follow",
-          cache: "no-store", // Prevent browser cache
-          headers: {
-            "Cache-Control": "no-cache, no-store, must-revalidate", // Ensure fresh request
-            "Pragma": "no-cache",  // HTTP/1.0 backward compatibility
-          }
-        });
-
-        if (!dataResponse.ok) throw new Error(`Failed to fetch CSV: ${dataResponse.statusText}`);
-
-        const csvText = await dataResponse.text();
-        Papa.parse<CsvMenuDataRow>(csvText, {
-          header: true,
-          skipEmptyLines: true,
-          dynamicTyping: false, // Prevent unintended type conversions
-          transform: (value, column) => {
-            if (column === "itemPrice" || column === "itemBulkPrice") {
-              return Number(value) || undefined;
-            }
-
-            return value;
-          },
-          error: (err: { message: string; }) => console.warn(`CSV Parsing Error: ${err.message}`),
-          complete: (result) => {
-            // Group by category and type first
-            const groupedData = result.data.reduce((acc, row) => {
-              // Create category if it doesn't exist
-              if (!acc[row.category]) {
-                acc[row.category] = {};
-              }
-
-              // Create type if it doesn't exist
-              if (!acc[row.category][row.typeName]) {
-                acc[row.category][row.typeName] = {
-                  items: [],
-                  description: row.typeDescription // Will take first occurrence
-                };
-              }
-
-              // Add item to the type
-              acc[row.category][row.typeName].items.push({
-                name: row.itemName,
-                description: row.itemDescription,
-                price: row.itemPrice,
-                bulkPrice: row.itemBulkPrice,
-              });
-
-              return acc;
-            }, {} as Record<string, Record<string, { items: MenuItem[], description?: string }>>);
-
-            // Transform into Menu structure with guaranteed food and drinks categories
-            const menu: Menu = {
-              food: {
-                sections: groupedData['FOOD'] ? Object.entries(groupedData['FOOD']).map(([typeName, data]) => ({
-                  type: typeName,
-                  description: data.description,
-                  items: data.items
-                })) : []
-              },
-              drinks: {
-                sections: groupedData['DRINKS'] ? Object.entries(groupedData['DRINKS']).map(([typeName, data]) => ({
-                  type: typeName,
-                  description: data.description,
-                  items: data.items
-                })) : []
-              }
-            };
-
-            // Store in localStorage with expiration
-            localStorage.setItem(CACHE_KEY, JSON.stringify(menu));
-            localStorage.setItem(CACHE_EXPIRATION_KEY, String(Date.now() + CACHE_TTL));
-
-            console.info('Fetched menu from source and updated cache.');
-
-            setMenu(menu);
-          },
-        });
-      } catch (e) {
-        console.info(`Fetching menu from source or cache failed (see error below), falling back to menu last updated on ${fallbackMenuDate}.`);
-        console.info(e);
-
-        setMenu(fallbackMenu);
-      }
+      fetchMenuData(MAIN_MENU_SHEET_LINK, setMenu, CACHE_KEY, CACHE_EXPIRATION_KEY, fallbackMainMenu, fallbackMainMenuDate);
     }
 
     fetchData();

--- a/website/src/components/navbar.tsx
+++ b/website/src/components/navbar.tsx
@@ -45,6 +45,11 @@ export const Navbar = () => {
               label="RESERVE"
             />
             <Separator />
+            <NavLink
+              href="/catering"
+              label="CATERING"
+            />
+            <Separator />
             <NavLink href="/contact" label="CONTACT" />
           </div>
 
@@ -103,6 +108,7 @@ export const Navbar = () => {
               href="https://www.waitlist.me/w/17334990070#"
               label="RESERVE"
             />
+            <NavLink href="/catering" label="CATERING" />
             <NavLink href="/contact" label="CONTACT" />
           </div>
 

--- a/website/src/data-fetcher/sheet-fetcher.ts
+++ b/website/src/data-fetcher/sheet-fetcher.ts
@@ -12,6 +12,11 @@ interface CsvMenuDataRow {
   itemBulkPrice?: number;
 }
 
+/**
+* This function (1) pulls csv data from the url, (2) parses the csv
+* (3) sets react state, and (4) caches menu data in browser.
+*/
+
 export async function fetchMenuData(dataUrl: string, setMenu: (menu : Menu) => void, cacheKey: string, cacheExpirationKey: string, fallbackMenu? : Menu, fallbackMenuDate? : string) {
   try {
     //const dataUrl = "https://docs.google.com/spreadsheets/d/e/2PACX-1vQFe8zXVdVW7slOpUu8hsp32MnnEz1ZGRivhEWJjaBUIWxz5jRXd8qYjKrZ05KEQG0F-kT1YFlFiSaZ/pub?output=csv";

--- a/website/src/data-fetcher/sheet-fetcher.ts
+++ b/website/src/data-fetcher/sheet-fetcher.ts
@@ -1,0 +1,105 @@
+import Papa from "papaparse";
+import { Menu, MenuItem } from "@/components/menu";
+import { CACHE_TTL } from "@/lib/constants";
+
+interface CsvMenuDataRow {
+  category: 'FOOD' | 'DRINKS';
+  typeName: string;
+  typeDescription?: string;
+  itemName: string;
+  itemDescription?: string;
+  itemPrice?: number;
+  itemBulkPrice?: number;
+}
+
+export async function fetchMenuData(dataUrl: string, setMenu: (menu : Menu) => void, cacheKey: string, cacheExpirationKey: string, fallbackMenu? : Menu, fallbackMenuDate? : string) {
+  try {
+    //const dataUrl = "https://docs.google.com/spreadsheets/d/e/2PACX-1vQFe8zXVdVW7slOpUu8hsp32MnnEz1ZGRivhEWJjaBUIWxz5jRXd8qYjKrZ05KEQG0F-kT1YFlFiSaZ/pub?output=csv";
+    const dataResponse = await fetch(dataUrl, {
+      redirect: "follow",
+      cache: "no-store", // Prevent browser cache
+      headers: {
+        "Cache-Control": "no-cache, no-store, must-revalidate", // Ensure fresh request
+        "Pragma": "no-cache",  // HTTP/1.0 backward compatibility
+      }
+    });
+
+    if (!dataResponse.ok) throw new Error(`Failed to fetch CSV: ${dataResponse.statusText}`);
+
+    const csvText = await dataResponse.text();
+    Papa.parse<CsvMenuDataRow>(csvText, {
+      header: true,
+      skipEmptyLines: true,
+      dynamicTyping: false, // Prevent unintended type conversions
+      transform: (value, column) => {
+        if (column === "itemPrice" || column === "itemBulkPrice") {
+          return Number(value) || undefined;
+        }
+
+        return value;
+      },
+      error: (err: { message: string; }) => console.warn(`CSV Parsing Error: ${err.message}`),
+      complete: (result) => {
+        // Group by category and type first
+        const groupedData = result.data.reduce((acc, row) => {
+          // Create category if it doesn't exist
+          if (!acc[row.category]) {
+            acc[row.category] = {};
+          }
+
+          // Create type if it doesn't exist
+          if (!acc[row.category][row.typeName]) {
+            acc[row.category][row.typeName] = {
+              items: [],
+              description: row.typeDescription // Will take first occurrence
+            };
+          }
+
+          // Add item to the type
+          acc[row.category][row.typeName].items.push({
+            name: row.itemName,
+            description: row.itemDescription,
+            price: row.itemPrice,
+            bulkPrice: row.itemBulkPrice,
+          });
+
+          return acc;
+        }, {} as Record<string, Record<string, { items: MenuItem[], description?: string }>>);
+
+        // Transform into Menu structure with guaranteed food and drinks categories
+        const menu: Menu = {
+          food: {
+            sections: groupedData['FOOD'] ? Object.entries(groupedData['FOOD']).map(([typeName, data]) => ({
+              type: typeName,
+              description: data.description,
+              items: data.items
+            })) : []
+          },
+          drinks: {
+            sections: groupedData['DRINKS'] ? Object.entries(groupedData['DRINKS']).map(([typeName, data]) => ({
+              type: typeName,
+              description: data.description,
+              items: data.items
+            })) : []
+          }
+        };
+
+
+        // Store in localStorage with expiration
+        localStorage.setItem(cacheKey, JSON.stringify(menu));
+        localStorage.setItem(cacheExpirationKey, String(Date.now() + CACHE_TTL));
+
+        console.info('Fetched menu from source and updated cache.');
+
+        setMenu(menu);
+      },
+    });
+  } catch (e) {
+    console.info(e);
+
+    if (fallbackMenu !== undefined) {
+      console.info(`Fetching menu from source or cache failed (see error below), falling back to menu last updated on ${fallbackMenuDate}.`);
+      setMenu(fallbackMenu);
+    }
+  }
+}

--- a/website/src/lib/constants.ts
+++ b/website/src/lib/constants.ts
@@ -452,3 +452,156 @@ export const fallbackMainMenu: Menu = {
         ]
     }
 }
+
+export const fallbackCateringMenuDate = '4/11/2025';
+export const fallbackCateringMenu: Menu = {
+  food: {
+    sections: [
+      {
+        type: "LUNCH BOX",
+        description: "Serves 10. Includes one of each below",
+        items: [
+          {
+            name: "Half Po Boy",
+            description: "choice of hot sausage, catfish or shrimp served fully dressed (can be split 5 and 5)",
+            price: 180.0
+          },
+          {
+            name: "Savory Side",
+            description: "choice of red beans and rice or gumbo",
+            price: undefined
+          },
+          {
+            name: "Fresh Side",
+            description: "choice of side salad or coleslaw",
+            price: undefined
+          }
+        ]
+      },
+      {
+        type: "STARTERS",
+        description: "Serves 10–15",
+        items: [
+          {
+            name: "Garden District Dip",
+            description: "cajun shrimp & crawfish dip served with french bread",
+            price: 140.0
+          },
+          {
+            name: "Audubon Crawfish Beignets",
+            description: "crawfish, scallion, and remoulade dipping sauce",
+            price: 120.00
+          }
+        ]
+      },
+      {
+        type: "ENTREES",
+        description: undefined,
+        items: [
+          {
+            name: "Red Beans & Rice",
+            description: "pork belly, red beans, smoked sausage and white rice",
+            price: 150.0
+          },
+          {
+            name: "Etouffee",
+            description: "smothered shrimp and crawfish served with white rice",
+            price: 220.0
+          },
+          {
+            name: "Vegan Dirty Rice",
+            description: "beyond meat, holy trinity, seasoned rice",
+            price: 240.0
+          },
+          {
+            name: "Jambalaya",
+            description: "andouille sausage, shrimp, holy trinity choice of pasta or rice",
+            price: 200.0
+          }
+        ]
+      },
+      {
+        type: "SIDES",
+        description: "Serves 10–15",
+        items: [
+          {
+            name: "Cajun Corn Maque Choux",
+            description: "cajun spiced corn, holy trinity and jalapeno blend",
+            price: 40.0
+          },
+          {
+            name: "House Salad",
+            description: "mixed greens, red onion, cheddar cheese, carrots, tomato and croutons with choice of dressing",
+            price: 45.0
+          },
+          {
+            name: "Baked Mac and Cheese",
+            description: "sharp cheddar mac and cheese",
+            price: 55.0
+          }
+        ]
+      },
+      {
+        type: "A LA CARTE",
+        description: undefined,
+        items: [
+          {
+            name: "Catfish Filets",
+            description: "10 fried catfish filets",
+            price: 75.0
+          },
+          {
+            name: "Fried Shrimp",
+            description: "3 pounds of fried shrimp",
+            price: 65.0
+          },
+          {
+            name: "Southern Hospitality Chicken",
+            description: "20 crispy cajun honey chicken thighs",
+            price: 50.0
+          },
+          {
+            name: "Muffuletta",
+            description: "8 half sandwiches: olive salad, capicola, mortadella, salami, mozzarella and provolone on sesame bread",
+            price: 65.0
+          }
+        ]
+      },
+      {
+        type: "DESSERTS",
+        description: undefined,
+        items: [
+          {
+            name: "Pecan Pound Cake",
+            description: "one bunt cake with home made glaze and heath topping",
+            price: 30.0
+          },
+          {
+            name: "Cookie",
+            description: "inquire about current flavor selection. price is per each",
+            price: 1.5
+          }
+        ]
+      },
+      {
+        type: "ADD ONS",
+        description: undefined,
+        items: [
+          {
+            name: "Remoulade Sauce",
+            description: "12 oz bottle",
+            price: 8.0
+          },
+          {
+            name: "Dressing",
+            description: "ranch, house, or caesar",
+            price: 6.0
+          }
+        ]
+      }
+    ]
+  },
+  drinks: {
+    sections: []
+  }
+};

--- a/website/src/lib/constants.ts
+++ b/website/src/lib/constants.ts
@@ -1,7 +1,9 @@
 import { Menu } from "@/components/menu";
 
-export const fallbackMenuDate = '2/14/2025';
-export const fallbackMenu: Menu = {
+export const CACHE_TTL = 1000 * 60 * 60 * 24; // 1 day expiration
+
+export const fallbackMainMenuDate = '2/14/2025';
+export const fallbackMainMenu: Menu = {
     food: {
         sections: [
             {


### PR DESCRIPTION
### Notes
* Website changes
  * Adding catering menu to website. Menu items have been added to the client's spreadsheet and website menu is being rendered from that data. 
  * The downloadable menu is currently hosted on personal google drive, will need to get client to host.
  * Changed the info banner to announce catering menu
* Refactoring
  * Pulled menu sheet pulling and parsing logic into separate function to reuse for catering menu.
  * The `Menu` component now takes in props for dataUrl, cacheKeys, and fallbackMenus and returns the populated menu components based on what is in the sheet 

![Screenshot 2025-04-11 at 3 35 22 PM](https://github.com/user-attachments/assets/c37f113d-86ab-4c82-b9c8-fe5ed4eb4735)
