### PR TITLE
Implementing dynamic menu tab rendering and menu loading screen

### DIFF
--- a/website/src/app/faq/page.tsx
+++ b/website/src/app/faq/page.tsx
@@ -2,6 +2,7 @@
 
 import { Navbar } from "@/components/navbar";
 import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "@/components/ui/accordion";
+import { Skeleton } from "@/components/ui/skeleton";
 import { fetchSheetData } from "@/data-fetcher/generic-fetcher";
 import { CACHE_TTL } from "@/lib/constants";
 import { useEffect, useState } from "react";
@@ -17,8 +18,10 @@ const FAQ_SHEET_LINK = "https://docs.google.com/spreadsheets/d/e/2PACX-1vQFe8zXV
 
 export default function FAQPage() {
   const [faqList, setFaqList] = useState<FaqRow[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
 
   useEffect(() => {
+    setLoading(true);
     async function fetchFAQs() {
       const faqRowList: FaqRow[] = await fetchSheetData<FaqRow>(FAQ_SHEET_LINK,
         row => ({
@@ -28,6 +31,7 @@ export default function FAQPage() {
 
       if (faqRowList !== undefined) {
         setFaqList(faqRowList)
+        console.log(faqRowList)
 
         localStorage.setItem(FAQ_CACHE_KEY, JSON.stringify(faqRowList));
         localStorage.setItem(FAQ_CACHE_EXPIRATION_KEY, String(Date.now() + CACHE_TTL));
@@ -37,15 +41,20 @@ export default function FAQPage() {
     }
 
     // TODO: move this into a reuseable cache getter/setter
+    const urlParams = new URLSearchParams(window.location.search);
+    const shouldRefresh = urlParams.has("refresh");
+
     const now = Date.now();
     const cachedFAQData = localStorage.getItem(FAQ_CACHE_KEY);
     const cachedFAQExpiration = localStorage.getItem(FAQ_CACHE_EXPIRATION_KEY);
     // Use cache if it exists & isn't expired
-    if (cachedFAQData && cachedFAQExpiration  && now < Number(cachedFAQExpiration)) {
+    if (cachedFAQData && cachedFAQExpiration && !shouldRefresh  && now < Number(cachedFAQExpiration)) {
       console.info('Fetched FAQs from cache.');
       setFaqList(JSON.parse(cachedFAQData))
+      setLoading(false);
     } else {
       fetchFAQs();
+      setLoading(false);
     }
   }, []);
 
@@ -55,20 +64,38 @@ export default function FAQPage() {
       <div className="min-h-screen w-full bg-[#f5f5f5] p-8">
         <div className="max-w-6xl mx-auto">
           <h1 className="text-center text-2xl font-bold">FAQs</h1>
-          <Accordion type="single" collapsible className="w-full">
           {
-            faqList.map((faq, i) => {
-              return (
-                <AccordionItem key={i.toString()} value={i.toString()}>
-                  <AccordionTrigger>{faq.question}</AccordionTrigger>
-                  <AccordionContent>
-                    {faq.answer}
-                  </AccordionContent>
-                </AccordionItem>
-              );
-            })
+            loading
+            ?
+            <div className="p-4 space-y-4">
+              <Skeleton className="h-6"/>
+              <Skeleton className="h-6"/>
+              <Skeleton className="h-6"/>
+              <Skeleton className="h-6"/>
+            </div>
+            :
+            <>
+            {
+              faqList.length === 0 ?
+                <p>No frequent questions yet. Ask us something!</p>
+                :
+                <Accordion type="single" collapsible className="w-full">
+                  {
+                    faqList.map((faq, i) => {
+                      return (
+                        <AccordionItem key={i.toString()} value={i.toString()}>
+                          <AccordionTrigger>{faq.question}</AccordionTrigger>
+                          <AccordionContent>
+                            {faq.answer}
+                          </AccordionContent>
+                        </AccordionItem>
+                      );
+                    })
+                  }
+                </Accordion>
+            }
+            </>
           }
-          </Accordion>
         </div>
       </div>
     </div>

--- a/website/src/app/menu/page.tsx
+++ b/website/src/app/menu/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Menu } from "@/components/menu";
 import { Navbar } from "@/components/navbar";
 import { fallbackMainMenu, fallbackMainMenuDate } from '@/lib/constants';

--- a/website/src/components/menu.tsx
+++ b/website/src/components/menu.tsx
@@ -3,12 +3,14 @@
 import { useEffect, useState } from 'react';
 import { MenuItemComponent } from "@/components/menu-item";
 import { fetchMenuData } from '@/data-fetcher/sheet-fetcher';
+import { Skeleton } from './ui/skeleton';
 
 
 
 export interface Menu {
   food: MenuCategory;
   drinks: MenuCategory;
+ // menusByCategory: Map<string,MenuCategory[]>;
 }
 
 export interface MenuCategory {
@@ -36,11 +38,14 @@ interface MenuProps {
   fallbackMenuDate: string;
 }
 export function Menu(props: MenuProps) {
-  const [menuCategorySelection, setMenuCategorySelection] = useState<'FOOD' | 'DRINKS'>('FOOD');
+  const [menuCategorySelection, setMenuCategorySelection] = useState<string>('FOOD');
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   // TODO: add "data loading" state here. Setting menu causes a flicker of prices when re-rendering menu
   const [menu, setMenu] = useState<Menu>(props.fallbackMenu);
 
   useEffect(() => {
+    setIsLoading(true);
+    console.log("set loading to true")
     const urlParams = new URLSearchParams(window.location.search);
     const shouldRefresh = urlParams.has("refresh");
 
@@ -51,7 +56,7 @@ export function Menu(props: MenuProps) {
     // Use cache if it exists & isn't expired & no refresh requested
     if (cachedData && cacheExpiration && !shouldRefresh && now < Number(cacheExpiration)) {
       setMenu(JSON.parse(cachedData));
-
+      setIsLoading(false);
       console.info('Fetched menu from cache.');
 
       return;
@@ -62,45 +67,63 @@ export function Menu(props: MenuProps) {
     }
 
     fetchData();
+    setIsLoading(false);
+
   }, [props]);
 
   return (
     <div className="min-h-screen w-full bg-[#f5f5f5] p-8">
       <div className="max-w-6xl mx-auto">
-        <div className="flex flex-row justify-center mb-12 space-x-2">
-          <button onClick={()=>{setMenuCategorySelection('FOOD')}} className="bg-[#483248] text-[#c17f59] hover:bg-[#702963] hover:text-[#FFD700] px-12 py-2">FOOD</button>
-          {
-            // TODO: populate this sections by seeing what is available in spreadsheet
-            menu.drinks.sections.length !== 0 &&
-            <button onClick={()=>{setMenuCategorySelection('DRINKS')}} className="bg-[#483248] text-[#c17f59] hover:bg-[#702963] hover:text-[#FFD700] px-12 py-2">DRINKS</button>
-          }
-
-
-        </div>
-        <div className="columns-1 md:columns-2 gap-4">
-          {
-            (menuCategorySelection === 'FOOD' ? menu.food : menu.drinks).sections.map((section, sectionIndex) => (
-              <div key={sectionIndex} className="bg-white p-8 shadow-lg flex flex-col break-inside-avoid mb-6">
-                <h2 className="text-3xl font-bold mb-4">{section.type}</h2>
-                {
-                  section.description &&
-                  <p className="text-sm mb-6">
-                    {section.description}
-                  </p>
-                }
-                {section.items.map((item, itemIndex) => (
-                  <MenuItemComponent
-                    key={itemIndex}
-                    name={item.name}
-                    description={item.description}
-                    price={item.price?.toString()}
-                    bulkPrice={item.bulkPrice?.toString()}
-                  />
+        {
+          isLoading ?
+          <>
+            <div className="columns-1 md:columns-2 gap-4 pt-16">
+              {Array.from({ length: 6 }).map((_, i) => (
+                  <div key={i} className="break-inside-avoid mb-4">
+                    <Skeleton className="h-96 w-full rounded-xl" />
+                  </div>
                 ))}
-              </div>
-            ))
-          }
-        </div>
+            </div>
+          </>
+          :
+          <>
+            <div className="flex flex-row justify-center mb-12 space-x-2">
+              <button onClick={()=>{setMenuCategorySelection('FOOD')}} className="bg-[#483248] text-[#c17f59] hover:bg-[#702963] hover:text-[#FFD700] px-12 py-2">FOOD</button>
+              {
+                // TODO: populate this sections by seeing what is available in spreadsheet
+                menu.drinks.sections.length !== 0 &&
+                <button onClick={()=>{setMenuCategorySelection('DRINKS')}} className="bg-[#483248] text-[#c17f59] hover:bg-[#702963] hover:text-[#FFD700] px-12 py-2">DRINKS</button>
+              }
+
+
+            </div>
+            <div className="columns-1 md:columns-2 gap-4">
+              {
+                (menuCategorySelection === 'FOOD' ? menu.food : menu.drinks).sections.map((section, sectionIndex) => (
+                  <div key={sectionIndex} className="bg-white p-8 shadow-lg flex flex-col break-inside-avoid mb-6">
+                    <h2 className="text-3xl font-bold mb-4">{section.type}</h2>
+                    {
+                      section.description &&
+                      <p className="text-sm mb-6">
+                        {section.description}
+                      </p>
+                    }
+                    {section.items.map((item, itemIndex) => (
+                      <MenuItemComponent
+                        key={itemIndex}
+                        name={item.name}
+                        description={item.description}
+                        price={item.price?.toString()}
+                        bulkPrice={item.bulkPrice?.toString()}
+                      />
+                    ))}
+                  </div>
+                ))
+              }
+            </div>
+          </>
+        }
+
       </div>
     </div>
   );

--- a/website/src/components/menu.tsx
+++ b/website/src/components/menu.tsx
@@ -1,16 +1,12 @@
-'use client';
+"use client";
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from "react";
 import { MenuItemComponent } from "@/components/menu-item";
-import { fetchMenuData } from '@/data-fetcher/sheet-fetcher';
-import { Skeleton } from './ui/skeleton';
-
-
+import { fetchMenuData } from "@/data-fetcher/sheet-fetcher";
+import { Skeleton } from "./ui/skeleton";
 
 export interface Menu {
-  food: MenuCategory;
-  drinks: MenuCategory;
- // menusByCategory: Map<string,MenuCategory[]>;
+  menusByCategory: Record<string, MenuCategory>;
 }
 
 export interface MenuCategory {
@@ -37,15 +33,16 @@ interface MenuProps {
   fallbackMenu: Menu;
   fallbackMenuDate: string;
 }
+
+
+
 export function Menu(props: MenuProps) {
-  const [menuCategorySelection, setMenuCategorySelection] = useState<string>('FOOD');
+  const [menuCategorySelection, setMenuCategorySelection] = useState<string>("FOOD");
   const [isLoading, setIsLoading] = useState<boolean>(true);
-  // TODO: add "data loading" state here. Setting menu causes a flicker of prices when re-rendering menu
-  const [menu, setMenu] = useState<Menu>(props.fallbackMenu);
+  const [menu, setMenu] = useState<Menu>();
 
   useEffect(() => {
     setIsLoading(true);
-    console.log("set loading to true")
     const urlParams = new URLSearchParams(window.location.search);
     const shouldRefresh = urlParams.has("refresh");
 
@@ -55,76 +52,94 @@ export function Menu(props: MenuProps) {
 
     // Use cache if it exists & isn't expired & no refresh requested
     if (cachedData && cacheExpiration && !shouldRefresh && now < Number(cacheExpiration)) {
-      setMenu(JSON.parse(cachedData));
-      setIsLoading(false);
-      console.info('Fetched menu from cache.');
+      const cachedDataJson = JSON.parse(cachedData);
+      // TODO: this "if" can be removed 24 hours after change is deployed
+      if ('food' in cachedDataJson || 'drinks' in cachedDataJson) {
+        console.log("Found old schema in cached data, fetching new data")
+        fetchData();
+        setIsLoading(false);
+      } else {
+        setMenu(JSON.parse(cachedData));
+        setIsLoading(false);
+        console.info("Fetched menu from cache.");
+      }
 
       return;
     }
 
     async function fetchData() {
-      fetchMenuData(props.menuSheetUrl, setMenu, props.cacheKey, props.cacheExpirationKey, props.fallbackMenu, props.fallbackMenuDate);
+      fetchMenuData(
+        props.menuSheetUrl,
+        setMenu,
+        props.cacheKey,
+        props.cacheExpirationKey,
+        props.fallbackMenu,
+        props.fallbackMenuDate,
+      );
     }
 
     fetchData();
     setIsLoading(false);
-
   }, [props]);
 
-  return (
-    <div className="min-h-screen w-full bg-[#f5f5f5] p-8">
-      <div className="max-w-6xl mx-auto">
-        {
-          isLoading ?
-          <>
-            <div className="columns-1 md:columns-2 gap-4 pt-16">
-              {Array.from({ length: 6 }).map((_, i) => (
-                  <div key={i} className="break-inside-avoid mb-4">
-                    <Skeleton className="h-96 w-full rounded-xl" />
-                  </div>
-                ))}
-            </div>
-          </>
-          :
-          <>
-            <div className="flex flex-row justify-center mb-12 space-x-2">
-              <button onClick={()=>{setMenuCategorySelection('FOOD')}} className="bg-[#483248] text-[#c17f59] hover:bg-[#702963] hover:text-[#FFD700] px-12 py-2">FOOD</button>
-              {
-                // TODO: populate this sections by seeing what is available in spreadsheet
-                menu.drinks.sections.length !== 0 &&
-                <button onClick={()=>{setMenuCategorySelection('DRINKS')}} className="bg-[#483248] text-[#c17f59] hover:bg-[#702963] hover:text-[#FFD700] px-12 py-2">DRINKS</button>
-              }
-
-
-            </div>
-            <div className="columns-1 md:columns-2 gap-4">
-              {
-                (menuCategorySelection === 'FOOD' ? menu.food : menu.drinks).sections.map((section, sectionIndex) => (
-                  <div key={sectionIndex} className="bg-white p-8 shadow-lg flex flex-col break-inside-avoid mb-6">
-                    <h2 className="text-3xl font-bold mb-4">{section.type}</h2>
-                    {
-                      section.description &&
-                      <p className="text-sm mb-6">
-                        {section.description}
-                      </p>
-                    }
-                    {section.items.map((item, itemIndex) => (
-                      <MenuItemComponent
-                        key={itemIndex}
-                        name={item.name}
-                        description={item.description}
-                        price={item.price?.toString()}
-                        bulkPrice={item.bulkPrice?.toString()}
-                      />
-                    ))}
-                  </div>
-                ))
-              }
-            </div>
-          </>
-        }
-
+  if (isLoading || !menu) {
+    return (
+      <div className="min-h-screen w-full bg-[#f5f5f5] p-8">
+        <div className="max-w-6xl mx-auto">
+          <div className="columns-1 md:columns-2 gap-4 pt-16">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="break-inside-avoid mb-4">
+                <Skeleton className="h-96 w-full rounded-xl" />
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
-    </div>
-  );
+    );
+  } else {
+    return (
+      <div className="min-h-screen w-full bg-[#f5f5f5] p-8">
+        <div className="max-w-6xl mx-auto">
+          {/* Menu Tabs */}
+          <div className="flex flex-row flex-wrap justify-center mb-12 gap-2">
+            {
+              Object.keys(menu.menusByCategory).map((key) => (
+                <button
+                  key={key}
+                  onClick={() => setMenuCategorySelection(key)}
+                  className="bg-[#483248] text-[#c17f59] hover:bg-[#702963] hover:text-[#FFD700] px-12 py-2"
+                >
+                  {key}
+                </button>
+              ))
+            }
+          </div>
+
+          {/* Menu Content */}
+          <div className="columns-1 md:columns-2 gap-4">
+            {menu.menusByCategory[menuCategorySelection]?.sections.map((section, sectionIndex) => (
+              <div
+                key={sectionIndex}
+                className="bg-white p-8 shadow-lg flex flex-col break-inside-avoid mb-6"
+              >
+                <h2 className="text-3xl font-bold mb-4">{section.type}</h2>
+                {section.description && (
+                  <p className="text-sm mb-6">{section.description}</p>
+                )}
+                {section.items.map((item, itemIndex) => (
+                  <MenuItemComponent
+                    key={itemIndex}
+                    name={item.name}
+                    description={item.description}
+                    price={item.price?.toString()}
+                    bulkPrice={item.bulkPrice?.toString()}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
 }

--- a/website/src/components/navbar.tsx
+++ b/website/src/components/navbar.tsx
@@ -52,6 +52,8 @@ export const Navbar = () => {
             />
             <Separator />
             <NavLink href="/contact" label="CONTACT" />
+            <Separator />
+            <NavLink href="/faq" label="FAQ" />
           </div>
 
           {/* Social Icons (Desktop) */}
@@ -111,6 +113,7 @@ export const Navbar = () => {
             />
             <NavLink href="/catering" label="CATERING" />
             <NavLink href="/contact" label="CONTACT" />
+            <NavLink href="/faq" label="FAQ" />
           </div>
 
           {/* Social Icons (Mobile) */}

--- a/website/src/components/ui/skeleton.tsx
+++ b/website/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-neutral-900/10 dark:bg-neutral-50/10", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/website/src/data-fetcher/generic-fetcher.ts
+++ b/website/src/data-fetcher/generic-fetcher.ts
@@ -1,3 +1,4 @@
+import Papa from "papaparse";
 
 export async function fetchSheetData<T>(csvDataUrl: string, mapper: (row: Record<string, string>) => T): Promise<T[]> {
   try {
@@ -13,19 +14,16 @@ export async function fetchSheetData<T>(csvDataUrl: string, mapper: (row: Record
     if (!dataResponse.ok) throw new Error(`Failed to fetch CSV: ${dataResponse.statusText}`);
 
     const csvText = await dataResponse.text();
-    const lines = csvText.trim().split('\n');
-    const headers = lines[0].split(',');
+    const parsed = Papa.parse<Record<string, string>>(csvText, {
+          header: true,
+          skipEmptyLines: true,
+        });
 
-    return lines.slice(1).map(line => {
-      const values = line.split(',');
-      const row: Record<string, string> = {};
+        if (parsed.errors.length) {
+          console.warn("CSV parse errors:", parsed.errors);
+        }
 
-      headers.forEach((header, index) => {
-        row[header.trim()] = values[index]?.trim() ?? '';
-      });
-
-      return mapper(row);
-    });
+        return parsed.data.map(mapper);
   } catch(e) {
     console.error(`Failed to fetch data from sheet ${csvDataUrl}. Returning empty array`);
     console.error(e);

--- a/website/src/lib/constants.ts
+++ b/website/src/lib/constants.ts
@@ -2,606 +2,642 @@ import { Menu } from "@/components/menu";
 
 export const CACHE_TTL = 1000 * 60 * 60 * 24; // 1 day expiration
 
-export const fallbackMainMenuDate = '2/14/2025';
+export const fallbackMainMenuDate = "2/14/2025";
 export const fallbackMainMenu: Menu = {
-    food: {
-        sections: [
+  menusByCategory: {
+    FOOD: {
+      sections: [
+        {
+          type: "STARTERS",
+          description: undefined,
+          items: [
             {
-                type: "STARTERS",
-                description: undefined,
-                items: [
-                    {
-                        name: "Irish Channel Mussels",
-                        description: "mussels | tomato & dry vermouth sauce | french bread",
-                        price: 16.00
-                    },
-                    {
-                        name: "Audubon Crawfish Beignets",
-                        description: "crawfish | scallion | remoulade dipping sauce",
-                        price: 12.00
-                    },
-                    {
-                        name: "Garden District Dip",
-                        description: "cajun shrimp & crawfish dip | french bread",
-                        price: 14.00
-                    },
-                    {
-                        name: "Uptown BBQ Shrimp",
-                        description: "sautéed shrimp | garlic | worcestershire-spiked butter sauce | french bread",
-                        price: 16.00
-                    }
-                ]
+              name: "Irish Channel Mussels",
+              description:
+                "mussels | tomato & dry vermouth sauce | french bread",
+              price: 16.0,
             },
             {
-                type: "PO BOYS",
-                description: "All come fully dressed with lettuce, tomato, pickle and remoulade sauce and a side of cajun fries | Add Etouffee to any po boy +$2.00",
-                items: [
-                    {
-                        name: "Shrimp",
-                        description: undefined,
-                        price: 16.00
-                    },
-                    {
-                        name: "Crawfish",
-                        description: undefined,
-                        price: 16.00
-                    },
-                    {
-                        name: "Catfish",
-                        description: undefined,
-                        price: 16.00
-                    },
-                    {
-                        name: "Hot Sausage",
-                        description: undefined,
-                        price: 14.00
-                    }
-                ]
+              name: "Audubon Crawfish Beignets",
+              description: "crawfish | scallion | remoulade dipping sauce",
+              price: 12.0,
             },
             {
-                type: "SALADS",
-                description: "Add Chicken +$4.00 | Add Shrimp +$6.00 | Add Salmon +$8.00",
-                items: [
-                    {
-                        name: "Sunburst Salad",
-                        description: "mixed greens | port infused dried cranberry | candied pecans | almonds | bleu cheese | raspberry vinaigrette",
-                        price: 14.00
-                    },
-                    {
-                        name: "Sassy Salmon Salad",
-                        description: "salmon | mixed greens | tomato | avocado | red onion | house dressing",
-                        price: 18.00
-                    },
-                    {
-                        name: "Garden District Caesar",
-                        description: "chicken $14.00 or shrimp $16.00 | romaine lettuce | parmesan cheese | croutons",
-                        price: undefined
-                    },
-                    {
-                        name: "House Salad",
-                        description: "mixed greens | red onion | white cheddar | carrots | tomato | croutons | choice of dressing",
-                        price: 10.00
-                    }
-                ]
+              name: "Garden District Dip",
+              description: "cajun shrimp & crawfish dip | french bread",
+              price: 14.0,
             },
             {
-                type: "MAIN COURSE",
-                description: undefined,
-                items: [
-                    {
-                        name: "Gumbo Yaya",
-                        description: "andouille sausage | rotisserie chicken | white rice | french bread",
-                        price: 19.00
-                    },
-                    {
-                        name: "Red Beans and Rice",
-                        description: "pork belly | red beans | smoked sausage | white rice",
-                        price: 19.00
-                    },
-                    {
-                        name: "Southern Hospitality",
-                        description: "crispy chicken thighs (2) | baked mac & cheese | side salad",
-                        price: 22.00
-                    },
-                    {
-                        name: "Etouffee",
-                        description: "smothered shrimp & crawfish | white rice",
-                        price: 23.00
-                    },
-                    {
-                        name: "Cajun Tomahawk",
-                        description: "cajun marinated pork tomahawk | seasonal vegetable | white rice",
-                        price: 26.00
-                    },
-                    {
-                        name: "Fried Seafood Platter",
-                        description: "shrimp | catfish | crawfish | house made coleslaw | cajun fries",
-                        price: 28.00
-                    },
-                    {
-                        name: "Jambalaya",
-                        description: "andouille sausage | shrimp | holy trinity | seasoned rice",
-                        price: 18.00
-                    },
-                    {
-                        name: "Blacked Fish of the Week",
-                        description: "featured blackened fish | corn maque choux | white rice",
-                        price: 18.00
-                    },
-                    {
-                        name: "Muffulatta",
-                        description: "olive salad | capicola | mortadella | salami | mozzarella",
-                        price: 16.00
-                    },
-                    {
-                        name: "Bourbon Street Steak",
-                        description: "10 oz NY Strip | Bourbon street steak sauce | seasonal vegetable | white rice",
-                        price: 26.00
-                    },
-                    {
-                        name: "Yakamein (Old Sober)",
-                        description: "noodles | cajun soy beef broth | beef | shrimp | marinated boiled egg | scallion",
-                        price: 18.00
-                    },
-                    {
-                        name: "Vegan Cajun Dirty Rice",
-                        description: "beyond meat | holy trinity | seasoned rice",
-                        price: 18.00
-                    }
-                ]
+              name: "Uptown BBQ Shrimp",
+              description:
+                "sautéed shrimp | garlic | worcestershire-spiked butter sauce | french bread",
+              price: 16.0,
+            },
+          ],
+        },
+        {
+          type: "PO BOYS",
+          description:
+            "All come fully dressed with lettuce, tomato, pickle and remoulade sauce and a side of cajun fries | Add Etouffee to any po boy +$2.00",
+          items: [
+            {
+              name: "Shrimp",
+              description: undefined,
+              price: 16.0,
             },
             {
-                type: "DESSERTS",
-                description: undefined,
-                items: [
-                    {
-                        name: "Banana's Foster",
-                        description: undefined,
-                        price: 10.00
-                    },
-                    {
-                        name: "Feature Dessert",
-                        description: undefined,
-                        price: 10.00
-                    },
-                    {
-                        name: "Seasonal Mousse",
-                        description: "Ask about current flavor selection.",
-                        price: 10.00
-                    },
-                    {
-                        name: "Little Scoop",
-                        description: "Ask about current flavor selection.",
-                        price: 6.00
-                    }
-                ]
+              name: "Crawfish",
+              description: undefined,
+              price: 16.0,
             },
             {
-                type: "SIDES",
-                description: undefined,
-                items: [
-                    {
-                        name: "Cajun Corn Maque Choux",
-                        description: undefined,
-                        price: 6.00
-                    },
-                    {
-                        name: "Seasonal Vegetable",
-                        description: undefined,
-                        price: 6.00
-                    },
-                    {
-                        name: "Cajun Fries",
-                        description: undefined,
-                        price: 6.00
-                    },
-                    {
-                        name: "Baked Mac & Cheese",
-                        description: undefined,
-                        price: 8.00
-                    },
-                    {
-                        name: "Side Salad",
-                        description: undefined,
-                        price: 7.00
-                    },
-                    {
-                        name: "Coleslaw",
-                        description: undefined,
-                        price: 4.00
-                    },
-                    {
-                        name: "White Rice",
-                        description: undefined,
-                        price: 3.00
-                    }
-                ]
-            }
-        ]
+              name: "Catfish",
+              description: undefined,
+              price: 16.0,
+            },
+            {
+              name: "Hot Sausage",
+              description: undefined,
+              price: 14.0,
+            },
+          ],
+        },
+        {
+          type: "SALADS",
+          description:
+            "Add Chicken +$4.00 | Add Shrimp +$6.00 | Add Salmon +$8.00",
+          items: [
+            {
+              name: "Sunburst Salad",
+              description:
+                "mixed greens | port infused dried cranberry | candied pecans | almonds | bleu cheese | raspberry vinaigrette",
+              price: 14.0,
+            },
+            {
+              name: "Sassy Salmon Salad",
+              description:
+                "salmon | mixed greens | tomato | avocado | red onion | house dressing",
+              price: 18.0,
+            },
+            {
+              name: "Garden District Caesar",
+              description:
+                "chicken $14.00 or shrimp $16.00 | romaine lettuce | parmesan cheese | croutons",
+              price: undefined,
+            },
+            {
+              name: "House Salad",
+              description:
+                "mixed greens | red onion | white cheddar | carrots | tomato | croutons | choice of dressing",
+              price: 10.0,
+            },
+          ],
+        },
+        {
+          type: "MAIN COURSE",
+          description: undefined,
+          items: [
+            {
+              name: "Gumbo Yaya",
+              description:
+                "andouille sausage | rotisserie chicken | white rice | french bread",
+              price: 19.0,
+            },
+            {
+              name: "Red Beans and Rice",
+              description:
+                "pork belly | red beans | smoked sausage | white rice",
+              price: 19.0,
+            },
+            {
+              name: "Southern Hospitality",
+              description:
+                "crispy chicken thighs (2) | baked mac & cheese | side salad",
+              price: 22.0,
+            },
+            {
+              name: "Etouffee",
+              description: "smothered shrimp & crawfish | white rice",
+              price: 23.0,
+            },
+            {
+              name: "Cajun Tomahawk",
+              description:
+                "cajun marinated pork tomahawk | seasonal vegetable | white rice",
+              price: 26.0,
+            },
+            {
+              name: "Fried Seafood Platter",
+              description:
+                "shrimp | catfish | crawfish | house made coleslaw | cajun fries",
+              price: 28.0,
+            },
+            {
+              name: "Jambalaya",
+              description:
+                "andouille sausage | shrimp | holy trinity | seasoned rice",
+              price: 18.0,
+            },
+            {
+              name: "Blacked Fish of the Week",
+              description:
+                "featured blackened fish | corn maque choux | white rice",
+              price: 18.0,
+            },
+            {
+              name: "Muffulatta",
+              description:
+                "olive salad | capicola | mortadella | salami | mozzarella",
+              price: 16.0,
+            },
+            {
+              name: "Bourbon Street Steak",
+              description:
+                "10 oz NY Strip | Bourbon street steak sauce | seasonal vegetable | white rice",
+              price: 26.0,
+            },
+            {
+              name: "Yakamein (Old Sober)",
+              description:
+                "noodles | cajun soy beef broth | beef | shrimp | marinated boiled egg | scallion",
+              price: 18.0,
+            },
+            {
+              name: "Vegan Cajun Dirty Rice",
+              description: "beyond meat | holy trinity | seasoned rice",
+              price: 18.0,
+            },
+          ],
+        },
+        {
+          type: "DESSERTS",
+          description: undefined,
+          items: [
+            {
+              name: "Banana's Foster",
+              description: undefined,
+              price: 10.0,
+            },
+            {
+              name: "Feature Dessert",
+              description: undefined,
+              price: 10.0,
+            },
+            {
+              name: "Seasonal Mousse",
+              description: "Ask about current flavor selection.",
+              price: 10.0,
+            },
+            {
+              name: "Little Scoop",
+              description: "Ask about current flavor selection.",
+              price: 6.0,
+            },
+          ],
+        },
+        {
+          type: "SIDES",
+          description: undefined,
+          items: [
+            {
+              name: "Cajun Corn Maque Choux",
+              description: undefined,
+              price: 6.0,
+            },
+            {
+              name: "Seasonal Vegetable",
+              description: undefined,
+              price: 6.0,
+            },
+            {
+              name: "Cajun Fries",
+              description: undefined,
+              price: 6.0,
+            },
+            {
+              name: "Baked Mac & Cheese",
+              description: undefined,
+              price: 8.0,
+            },
+            {
+              name: "Side Salad",
+              description: undefined,
+              price: 7.0,
+            },
+            {
+              name: "Coleslaw",
+              description: undefined,
+              price: 4.0,
+            },
+            {
+              name: "White Rice",
+              description: undefined,
+              price: 3.0,
+            },
+          ],
+        },
+      ],
     },
-    drinks: {
-        sections: [
+    DRINKS: {
+      sections: [
+        {
+          type: "DRAFTS",
+          description: "Ask your server about rotating drafts.",
+          items: [
             {
-                type: "DRAFTS",
-                description: "Ask your server about rotating drafts.",
-                items: [
-                    {
-                        name: "Abita Strawberry Lager",
-                        description: undefined,
-                        price: 11.00
-                    },
-                    {
-                        name: "Abita Purple Haze",
-                        description: undefined,
-                        price: 11.00
-                    },
-                    {
-                        name: "Bells Two Hearted",
-                        description: undefined,
-                        price: 10.00
-                    },
-                    {
-                        name: "Modelo",
-                        description: undefined,
-                        price: 9.00
-                    },
-                    {
-                        name: "Stella Artois",
-                        description: undefined,
-                        price: 11.00
-                    }
-                ]
+              name: "Abita Strawberry Lager",
+              description: undefined,
+              price: 11.0,
             },
             {
-                type: "COCKTAILS",
-                description: undefined,
-                items: [
-                    {
-                        name: "Whispers of Sazerac",
-                        description: "Sazerac | absinthe liqueur | sugar cube | Psychaud's bitters",
-                        price: 14.00
-                    },
-                    {
-                        name: "Honey Child",
-                        description: "Empress Indigo gin | honey simple syrup | elderflower liquor | lemon juice | egg white | club soda",
-                        price: 12.00
-                    },
-                    {
-                        name: "Blooming Fleur De Lis",
-                        description: "Butterfly pea flower infused tequila | dry vermouth | agave syrup | orange bitters",
-                        price: 12.00
-                    },
-                    {
-                        name: "Mystical Misbelief Tree",
-                        description: "Vodka | peach syrup | lemon juice | mint | maraschino cherry | club soda",
-                        price: 12.00
-                    },
-                    {
-                        name: "Cafe Du Monde Martini",
-                        description: "Vodka | Bailey's | chicory pecan bitters | cafe du monde coffee | sweet condensed milk",
-                        price: 12.00
-                    },
-                    {
-                        name: "Hurricane",
-                        description: "Rum | passion fruit juice | lemon juice | pineapple juice | simple syrup | grenadine",
-                        price: 12.00
-                    },
-                    {
-                        name: "Faux Nana'",
-                        description: "Rum | lime juice | pineapple juice | orange juice | cranberry juice | banana puree | grenadine | all spice",
-                        price: 10.00
-                    }
-                ]
+              name: "Abita Purple Haze",
+              description: undefined,
+              price: 11.0,
             },
             {
-                type: "DAIQUIRIS",
-                description: undefined,
-                items: [
-                    {
-                        name: "Southern Peach",
-                        description: undefined,
-                        price: 12.00
-                    },
-                    {
-                        name: "Strawberry",
-                        description: undefined,
-                        price: 12.00
-                    },
-                    {
-                        name: "Tropical",
-                        description: undefined,
-                        price: 12.00
-                    },
-                    {
-                        name: "High Octane",
-                        description: undefined,
-                        price: 14.00
-                    }
-                ]
+              name: "Bells Two Hearted",
+              description: undefined,
+              price: 10.0,
             },
             {
-                type: "N/A BEVERAGES",
-                description: undefined,
-                items: [
-                    {
-                        name: "Peach Spritz",
-                        description: undefined,
-                        price: 6.00
-                    },
-                    {
-                        name: "Blackberry Mojito",
-                        description: undefined,
-                        price: 6.00
-                    },
-                    {
-                        name: "Strawberry Ginger Limeade",
-                        description: undefined,
-                        price: 6.00
-                    },
-                    {
-                        name: "Flavored Lemonade",
-                        description: "Peach, Strawberry, Mango, Blackberry, Pineapple, Passion Fruit",
-                        price: 4.00
-                    },
-                    {
-                        name: "Cold Drinks",
-                        description: undefined,
-                        price: 3.00
-                    },
-                    {
-                        name: "Sweet/Unsweet Iced Tea",
-                        description: undefined,
-                        price: 4.00
-                    },
-                    {
-                        name: "Hot Tea",
-                        description: undefined,
-                        price: 5.00
-                    },
-                    {
-                        name: "Cafe Du Monde Coffee",
-                        description: undefined,
-                        price: 5.00
-                    }
-                ]
+              name: "Modelo",
+              description: undefined,
+              price: 9.0,
             },
             {
-                type: "WHITE WINE",
-                description: undefined,
-                items: [
-                    {
-                        name: "CGT Semi Dry Riesling, Michigan",
-                        description: undefined,
-                        price: 9.00,
-                        bulkPrice: 40.00,
-                    },
-                    {
-                        name: "Arca Nova Vinho Verde, Portugal",
-                        description: undefined,
-                        price: 8.00,
-                        bulkPrice: 38.00,
-                    },
-                    {
-                        name: "Te Henga Sauvignon Blanc, New Zealand",
-                        description: undefined,
-                        price: 9.00,
-                        bulkPrice: 40.00,
-                    },
-                    {
-                        name: "HB Picpou de Pinet, France",
-                        description: undefined,
-                        price: 9.00,
-                        bulkPrice: 40.00,
-                    },
-                    {
-                        name: "Jadot Macon Blanc Chardonnay, France",
-                        description: undefined,
-                        price: 12.00,
-                        bulkPrice: 46.00,
-                    }
-                ]
+              name: "Stella Artois",
+              description: undefined,
+              price: 11.0,
+            },
+          ],
+        },
+        {
+          type: "COCKTAILS",
+          description: undefined,
+          items: [
+            {
+              name: "Whispers of Sazerac",
+              description:
+                "Sazerac | absinthe liqueur | sugar cube | Psychaud's bitters",
+              price: 14.0,
             },
             {
-                type: "RED WINE",
-                description: undefined,
-                items: [
-                    {
-                        name: "Parducci Small Lot Pinot Nior, Mendocino",
-                        description: undefined,
-                        price: 9.00,
-                        bulkPrice: 40.00,
-                    },
-                    {
-                        name: "Raeburn Cabernet Sauvignon, Sonoma",
-                        description: undefined,
-                        price: 12.00,
-                        bulkPrice: 46.00,
-                    },
-                    {
-                        name: "Carra Beaujolias Village, France",
-                        description: undefined,
-                        price: 12.00,
-                        bulkPrice: 46.00,
-                    },
-                    {
-                        name: "Montebuena Rioja, Spain",
-                        description: undefined,
-                        price: 9.00,
-                        bulkPrice: 40.00,
-                    }
-                ]
+              name: "Honey Child",
+              description:
+                "Empress Indigo gin | honey simple syrup | elderflower liquor | lemon juice | egg white | club soda",
+              price: 12.0,
             },
             {
-                type: "BUBBLES",
-                description: undefined,
-                items: [
-                    {
-                        name: "Freixenet Prosecco Rose, Italy",
-                        description: undefined,
-                        price: 14.00,
-                        bulkPrice: 54.00,
-                    },
-                    {
-                        name: "Segura Viudas Brut, France",
-                        description: undefined,
-                        price: 14.00,
-                        bulkPrice: 54.00,
-                    }
-                ]
-            }
-        ]
-    }
-}
-
-export const fallbackCateringMenuDate = '4/11/2025';
-export const fallbackCateringMenu: Menu = {
-  food: {
-    sections: [
-      {
-        type: "LUNCH BOX",
-        description: "Serves 10. Includes one of each below",
-        items: [
-          {
-            name: "Half Po Boy",
-            description: "choice of hot sausage, catfish or shrimp served fully dressed (can be split 5 and 5)",
-            price: 180.0
-          },
-          {
-            name: "Savory Side",
-            description: "choice of red beans and rice or gumbo",
-            price: undefined
-          },
-          {
-            name: "Fresh Side",
-            description: "choice of side salad or coleslaw",
-            price: undefined
-          }
-        ]
-      },
-      {
-        type: "STARTERS",
-        description: "Serves 10–15",
-        items: [
-          {
-            name: "Garden District Dip",
-            description: "cajun shrimp & crawfish dip served with french bread",
-            price: 140.0
-          },
-          {
-            name: "Audubon Crawfish Beignets",
-            description: "crawfish, scallion, and remoulade dipping sauce",
-            price: 120.00
-          }
-        ]
-      },
-      {
-        type: "ENTREES",
-        description: undefined,
-        items: [
-          {
-            name: "Red Beans & Rice",
-            description: "pork belly, red beans, smoked sausage and white rice",
-            price: 150.0
-          },
-          {
-            name: "Etouffee",
-            description: "smothered shrimp and crawfish served with white rice",
-            price: 220.0
-          },
-          {
-            name: "Vegan Dirty Rice",
-            description: "beyond meat, holy trinity, seasoned rice",
-            price: 240.0
-          },
-          {
-            name: "Jambalaya",
-            description: "andouille sausage, shrimp, holy trinity choice of pasta or rice",
-            price: 200.0
-          }
-        ]
-      },
-      {
-        type: "SIDES",
-        description: "Serves 10–15",
-        items: [
-          {
-            name: "Cajun Corn Maque Choux",
-            description: "cajun spiced corn, holy trinity and jalapeno blend",
-            price: 40.0
-          },
-          {
-            name: "House Salad",
-            description: "mixed greens, red onion, cheddar cheese, carrots, tomato and croutons with choice of dressing",
-            price: 45.0
-          },
-          {
-            name: "Baked Mac and Cheese",
-            description: "sharp cheddar mac and cheese",
-            price: 55.0
-          }
-        ]
-      },
-      {
-        type: "A LA CARTE",
-        description: undefined,
-        items: [
-          {
-            name: "Catfish Filets",
-            description: "10 fried catfish filets",
-            price: 75.0
-          },
-          {
-            name: "Fried Shrimp",
-            description: "3 pounds of fried shrimp",
-            price: 65.0
-          },
-          {
-            name: "Southern Hospitality Chicken",
-            description: "20 crispy cajun honey chicken thighs",
-            price: 50.0
-          },
-          {
-            name: "Muffuletta",
-            description: "8 half sandwiches: olive salad, capicola, mortadella, salami, mozzarella and provolone on sesame bread",
-            price: 65.0
-          }
-        ]
-      },
-      {
-        type: "DESSERTS",
-        description: undefined,
-        items: [
-          {
-            name: "Pecan Pound Cake",
-            description: "one bunt cake with home made glaze and heath topping",
-            price: 30.0
-          },
-          {
-            name: "Cookie",
-            description: "inquire about current flavor selection. price is per each",
-            price: 1.5
-          }
-        ]
-      },
-      {
-        type: "ADD ONS",
-        description: undefined,
-        items: [
-          {
-            name: "Remoulade Sauce",
-            description: "12 oz bottle",
-            price: 8.0
-          },
-          {
-            name: "Dressing",
-            description: "ranch, house, or caesar",
-            price: 6.0
-          }
-        ]
-      }
-    ]
+              name: "Blooming Fleur De Lis",
+              description:
+                "Butterfly pea flower infused tequila | dry vermouth | agave syrup | orange bitters",
+              price: 12.0,
+            },
+            {
+              name: "Mystical Misbelief Tree",
+              description:
+                "Vodka | peach syrup | lemon juice | mint | maraschino cherry | club soda",
+              price: 12.0,
+            },
+            {
+              name: "Cafe Du Monde Martini",
+              description:
+                "Vodka | Bailey's | chicory pecan bitters | cafe du monde coffee | sweet condensed milk",
+              price: 12.0,
+            },
+            {
+              name: "Hurricane",
+              description:
+                "Rum | passion fruit juice | lemon juice | pineapple juice | simple syrup | grenadine",
+              price: 12.0,
+            },
+            {
+              name: "Faux Nana'",
+              description:
+                "Rum | lime juice | pineapple juice | orange juice | cranberry juice | banana puree | grenadine | all spice",
+              price: 10.0,
+            },
+          ],
+        },
+        {
+          type: "DAIQUIRIS",
+          description: undefined,
+          items: [
+            {
+              name: "Southern Peach",
+              description: undefined,
+              price: 12.0,
+            },
+            {
+              name: "Strawberry",
+              description: undefined,
+              price: 12.0,
+            },
+            {
+              name: "Tropical",
+              description: undefined,
+              price: 12.0,
+            },
+            {
+              name: "High Octane",
+              description: undefined,
+              price: 14.0,
+            },
+          ],
+        },
+        {
+          type: "N/A BEVERAGES",
+          description: undefined,
+          items: [
+            {
+              name: "Peach Spritz",
+              description: undefined,
+              price: 6.0,
+            },
+            {
+              name: "Blackberry Mojito",
+              description: undefined,
+              price: 6.0,
+            },
+            {
+              name: "Strawberry Ginger Limeade",
+              description: undefined,
+              price: 6.0,
+            },
+            {
+              name: "Flavored Lemonade",
+              description:
+                "Peach, Strawberry, Mango, Blackberry, Pineapple, Passion Fruit",
+              price: 4.0,
+            },
+            {
+              name: "Cold Drinks",
+              description: undefined,
+              price: 3.0,
+            },
+            {
+              name: "Sweet/Unsweet Iced Tea",
+              description: undefined,
+              price: 4.0,
+            },
+            {
+              name: "Hot Tea",
+              description: undefined,
+              price: 5.0,
+            },
+            {
+              name: "Cafe Du Monde Coffee",
+              description: undefined,
+              price: 5.0,
+            },
+          ],
+        },
+        {
+          type: "WHITE WINE",
+          description: undefined,
+          items: [
+            {
+              name: "CGT Semi Dry Riesling, Michigan",
+              description: undefined,
+              price: 9.0,
+              bulkPrice: 40.0,
+            },
+            {
+              name: "Arca Nova Vinho Verde, Portugal",
+              description: undefined,
+              price: 8.0,
+              bulkPrice: 38.0,
+            },
+            {
+              name: "Te Henga Sauvignon Blanc, New Zealand",
+              description: undefined,
+              price: 9.0,
+              bulkPrice: 40.0,
+            },
+            {
+              name: "HB Picpou de Pinet, France",
+              description: undefined,
+              price: 9.0,
+              bulkPrice: 40.0,
+            },
+            {
+              name: "Jadot Macon Blanc Chardonnay, France",
+              description: undefined,
+              price: 12.0,
+              bulkPrice: 46.0,
+            },
+          ],
+        },
+        {
+          type: "RED WINE",
+          description: undefined,
+          items: [
+            {
+              name: "Parducci Small Lot Pinot Nior, Mendocino",
+              description: undefined,
+              price: 9.0,
+              bulkPrice: 40.0,
+            },
+            {
+              name: "Raeburn Cabernet Sauvignon, Sonoma",
+              description: undefined,
+              price: 12.0,
+              bulkPrice: 46.0,
+            },
+            {
+              name: "Carra Beaujolias Village, France",
+              description: undefined,
+              price: 12.0,
+              bulkPrice: 46.0,
+            },
+            {
+              name: "Montebuena Rioja, Spain",
+              description: undefined,
+              price: 9.0,
+              bulkPrice: 40.0,
+            },
+          ],
+        },
+        {
+          type: "BUBBLES",
+          description: undefined,
+          items: [
+            {
+              name: "Freixenet Prosecco Rose, Italy",
+              description: undefined,
+              price: 14.0,
+              bulkPrice: 54.0,
+            },
+            {
+              name: "Segura Viudas Brut, France",
+              description: undefined,
+              price: 14.0,
+              bulkPrice: 54.0,
+            },
+          ],
+        },
+      ],
+    },
   },
-  drinks: {
-    sections: []
-  }
+};
+
+export const fallbackCateringMenuDate = "4/11/2025";
+export const fallbackCateringMenu: Menu = {
+  menusByCategory: {
+    FOOD: {
+      sections: [
+        {
+          type: "LUNCH BOX",
+          description: "Serves 10. Includes one of each below",
+          items: [
+            {
+              name: "Half Po Boy",
+              description:
+                "choice of hot sausage, catfish or shrimp served fully dressed (can be split 5 and 5)",
+              price: 180.0,
+            },
+            {
+              name: "Savory Side",
+              description: "choice of red beans and rice or gumbo",
+              price: undefined,
+            },
+            {
+              name: "Fresh Side",
+              description: "choice of side salad or coleslaw",
+              price: undefined,
+            },
+          ],
+        },
+        {
+          type: "STARTERS",
+          description: "Serves 10–15",
+          items: [
+            {
+              name: "Garden District Dip",
+              description:
+                "cajun shrimp & crawfish dip served with french bread",
+              price: 140.0,
+            },
+            {
+              name: "Audubon Crawfish Beignets",
+              description: "crawfish, scallion, and remoulade dipping sauce",
+              price: 120.0,
+            },
+          ],
+        },
+        {
+          type: "ENTREES",
+          description: undefined,
+          items: [
+            {
+              name: "Red Beans & Rice",
+              description:
+                "pork belly, red beans, smoked sausage and white rice",
+              price: 150.0,
+            },
+            {
+              name: "Etouffee",
+              description:
+                "smothered shrimp and crawfish served with white rice",
+              price: 220.0,
+            },
+            {
+              name: "Vegan Dirty Rice",
+              description: "beyond meat, holy trinity, seasoned rice",
+              price: 240.0,
+            },
+            {
+              name: "Jambalaya",
+              description:
+                "andouille sausage, shrimp, holy trinity choice of pasta or rice",
+              price: 200.0,
+            },
+          ],
+        },
+        {
+          type: "SIDES",
+          description: "Serves 10–15",
+          items: [
+            {
+              name: "Cajun Corn Maque Choux",
+              description: "cajun spiced corn, holy trinity and jalapeno blend",
+              price: 40.0,
+            },
+            {
+              name: "House Salad",
+              description:
+                "mixed greens, red onion, cheddar cheese, carrots, tomato and croutons with choice of dressing",
+              price: 45.0,
+            },
+            {
+              name: "Baked Mac and Cheese",
+              description: "sharp cheddar mac and cheese",
+              price: 55.0,
+            },
+          ],
+        },
+        {
+          type: "A LA CARTE",
+          description: undefined,
+          items: [
+            {
+              name: "Catfish Filets",
+              description: "10 fried catfish filets",
+              price: 75.0,
+            },
+            {
+              name: "Fried Shrimp",
+              description: "3 pounds of fried shrimp",
+              price: 65.0,
+            },
+            {
+              name: "Southern Hospitality Chicken",
+              description: "20 crispy cajun honey chicken thighs",
+              price: 50.0,
+            },
+            {
+              name: "Muffuletta",
+              description:
+                "8 half sandwiches: olive salad, capicola, mortadella, salami, mozzarella and provolone on sesame bread",
+              price: 65.0,
+            },
+          ],
+        },
+        {
+          type: "DESSERTS",
+          description: undefined,
+          items: [
+            {
+              name: "Pecan Pound Cake",
+              description:
+                "one bunt cake with home made glaze and heath topping",
+              price: 30.0,
+            },
+            {
+              name: "Cookie",
+              description:
+                "inquire about current flavor selection. price is per each",
+              price: 1.5,
+            },
+          ],
+        },
+        {
+          type: "ADD ONS",
+          description: undefined,
+          items: [
+            {
+              name: "Remoulade Sauce",
+              description: "12 oz bottle",
+              price: 8.0,
+            },
+            {
+              name: "Dressing",
+              description: "ranch, house, or caesar",
+              price: 6.0,
+            },
+          ],
+        },
+      ],
+    },
+  },
 };


### PR DESCRIPTION
# Viewable Changes
* Menu tabs (food, drink, brunch, etc) are now rendered based on whatever is in the sheet
* Any data fetching page (menus and faq) now have a loading skeleton state. This removes the price flickering from setting initial state to the fallback
* FAQ is now added to nav bar. If no questions are added, which currently there are none. It will show a default message

# "Backend" changes
* moved to papa parse for generic data fetcher
* changed menu interface to just a Record instead of explicit fields for food and drink
* To prevent error from trying to render old schema cached data, if cached data is of old schema, fresh pull will be forced
* Added cache busting to FAQ page
* Updated fallback menus to new schema


![Screenshot 2025-04-17 at 9 21 19 PM](https://github.com/user-attachments/assets/c1f27b50-ff64-43cd-8577-c6fb4c3fe37e)
